### PR TITLE
Update command to open Cypress

### DIFF
--- a/src/openSpecFile.js
+++ b/src/openSpecFile.js
@@ -39,7 +39,7 @@ exports.openSpecFile = (type, filename) => {
       ? { command: commandForRun, arg: `--spec "${relativePath}"` }
       : {
           command: commandForOpen,
-          arg: `--config testFiles="${absolutePath}"`
+          arg: `--config e2e.specPattern="${absolutePath}"`
         };
   terminal.sendText(`${exec.command} ${exec.arg}`);
 };


### PR DESCRIPTION
`testFiles` option is deprecated in Cypress v10 so opening test file does not work anymore. This change updates it to the new `e2e.specPattern` so the helper remains usable with new versions of Cypress.